### PR TITLE
Extract Strings added in #102

### DIFF
--- a/app/src/main/java/com/b_lam/resplash/ui/autowallpaper/AutoWallpaperSettingsActivity.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/autowallpaper/AutoWallpaperSettingsActivity.kt
@@ -147,10 +147,8 @@ class AutoWallpaperSettingsActivity :
 
     private fun showExternalStorageWarningDialog() {
         MaterialAlertDialogBuilder(this)
-            .setTitle("Installed on SD card?")
-            .setMessage("Hey there! We've noticed you've decided to move this application to " +
-                    "the SD card. Unfortunately, due to a limitation in Android, this means that " +
-                    "the Auto Wallpaper feature might not work properly. You have been warned!")
+            .setTitle(R.string.auto_wallpaper_external_storage_title)
+            .setMessage(R.string.auto_wallpaper_external_storage_message)
             .setPositiveButton(R.string.ok, null)
             .create()
             .show()

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -165,6 +165,8 @@
     <string name="auto_wallpaper_collection_url">Sammlungs-URL</string>
     <string name="auto_wallpaper_add_collection">Sammlung hinzufügen</string>
     <string name="auto_wallpaper_invalid_url">Ungültige URL</string>
+    <string name="auto_wallpaper_external_storage_title">Auf SD-Karte installiert?</string>
+    <string name="auto_wallpaper_external_storage_message">Hi! Wir haben gemerkt, dass du diese App auf eine SD-Karte installiert hast. Aufgrund technischer Beschränkungen in Android kann es sein, dass Auto-Wallpaper dadurch nicht richtig funktioniert. Du wurdest gewarnt!</string>
 
     <!-- Photo Detail -->
     <string name="views">Aufrufe</string>
@@ -201,7 +203,7 @@
     <string name="last_name_hint">Nachname</string>
     <string name="email_hint">E-Mail-Adresse</string>
     <string name="portfolio_hint">Persönliche Webseite/Portfolio</string>
-    <string name="instagram_username_hint">Instagram-Benuzername</string>
+    <string name="instagram_username_hint">Instagram-Benutzername</string>
     <string name="location_hint">Standort</string>
     <string name="bio_hint">Bio</string>
     <string name="account_updated">Konto aktualisiert!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -187,6 +187,8 @@
     <string name="auto_wallpaper_collection_url">Collection URL</string>
     <string name="auto_wallpaper_add_collection">Add Collection</string>
     <string name="auto_wallpaper_invalid_url">Invalid URL</string>
+    <string name="auto_wallpaper_external_storage_title">Installed on SD card?</string>
+    <string name="auto_wallpaper_external_storage_message">Hey there! We've noticed you've decided to move this application to the SD card. Unfortunately, due to a limitation in Android, this means that the Auto Wallpaper feature might not work properly. You have been warned!</string>
 
     <!-- Photo Detail -->
     <string name="location_template" translatable="false">%s, %s</string>


### PR DESCRIPTION
I extracted the strings that were added for the external storage warning dialog in #102 and added the corresponding German translations (I also fixed the missing 't' I pointed out in 1b72143 by the way, sorry for the fuss!).