### PR TITLE
Fix an issue where JSON parsing for collections API is failing due Unsplash API update.

### DIFF
--- a/app/src/main/java/com/b_lam/resplash/data/autowallpaper/AutoWallpaperCollectionDao.kt
+++ b/app/src/main/java/com/b_lam/resplash/data/autowallpaper/AutoWallpaperCollectionDao.kt
@@ -14,10 +14,10 @@ interface AutoWallpaperCollectionDao {
     fun getSelectedAutoWallpaperCollections(): LiveData<List<AutoWallpaperCollection>>
 
     @Query("SELECT id FROM auto_wallpaper_collections")
-    fun getSelectedAutoWallpaperCollectionIds(): LiveData<List<Int>>
+    fun getSelectedAutoWallpaperCollectionIds(): LiveData<List<String>>
 
     @Query("SELECT id FROM auto_wallpaper_collections LIMIT 1 OFFSET :offset")
-    suspend fun getRandomAutoWallpaperCollectionId(offset: Int): Int?
+    suspend fun getRandomAutoWallpaperCollectionId(offset: Int): String?
 
     @Query("SELECT COUNT(*) FROM auto_wallpaper_collections")
     suspend fun getNumberOfAutoWallpaperCollections(): Int
@@ -26,11 +26,11 @@ interface AutoWallpaperCollectionDao {
     fun getNumberOfAutoWallpaperCollectionsLiveData(): LiveData<Int>
 
     @Query("SELECT COUNT(*) FROM auto_wallpaper_collections WHERE id = :id")
-    fun getCountById(id: Int): LiveData<Int>
+    fun getCountById(id: String): LiveData<Int>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(collection: AutoWallpaperCollection)
 
     @Query("DELETE FROM auto_wallpaper_collections WHERE id = :id")
-    suspend fun delete(id: Int)
+    suspend fun delete(id: String)
 }

--- a/app/src/main/java/com/b_lam/resplash/data/autowallpaper/AutoWallpaperDatabase.kt
+++ b/app/src/main/java/com/b_lam/resplash/data/autowallpaper/AutoWallpaperDatabase.kt
@@ -10,7 +10,7 @@ import com.b_lam.resplash.data.autowallpaper.model.AutoWallpaperHistory
         AutoWallpaperHistory::class,
         AutoWallpaperCollection::class
     ],
-    version = 1,
+    version = 2,
     exportSchema = false
 )
 abstract class AutoWallpaperDatabase : RoomDatabase() {

--- a/app/src/main/java/com/b_lam/resplash/data/autowallpaper/model/AutoWallpaperCollection.kt
+++ b/app/src/main/java/com/b_lam/resplash/data/autowallpaper/model/AutoWallpaperCollection.kt
@@ -12,7 +12,7 @@ import androidx.room.PrimaryKey
 )
 data class AutoWallpaperCollection(
 
-    @PrimaryKey val id: Int? = null,
+    @PrimaryKey val id: String,
     val title: String? = null,
     val user_name: String? = null,
     val cover_photo: String? = null,

--- a/app/src/main/java/com/b_lam/resplash/data/collection/CollectionService.kt
+++ b/app/src/main/java/com/b_lam/resplash/data/collection/CollectionService.kt
@@ -16,19 +16,19 @@ interface CollectionService {
 
     @GET("collections/{id}")
     suspend fun getCollection(
-        @Path("id") id: Int
+        @Path("id") id: String
     ): Collection
 
     @GET("collections/{id}/photos")
     suspend fun getCollectionPhotos(
-        @Path("id") id: Int,
+        @Path("id") id: String,
         @Query("page") page: Int?,
         @Query("per_page") per_page: Int?
     ): List<Photo>
 
     @GET("collections/{id}/related")
     suspend fun getRelatedCollections(
-        @Path("id") id: Int
+        @Path("id") id: String
     ): List<Collection>
 
     @POST("collections")
@@ -40,7 +40,7 @@ interface CollectionService {
 
     @PUT("collections/{id}")
     suspend fun updateCollection(
-        @Path("id") id: Int,
+        @Path("id") id: String,
         @Query("title") title: String?,
         @Query("description") description: String?,
         @Query("private") private: Boolean?
@@ -48,18 +48,18 @@ interface CollectionService {
 
     @DELETE("collections/{id}")
     suspend fun deleteCollection(
-        @Path("id") id: Int
+        @Path("id") id: String
     ): Response<Unit>
 
     @POST("collections/{collection_id}/add")
     suspend fun addPhotoToCollection(
-        @Path("collection_id") collection_id: Int,
+        @Path("collection_id") collection_id: String,
         @Query("photo_id") photo_id: String
     ): CollectionPhotoResult
 
     @DELETE("collections/{collection_id}/remove")
     suspend fun removePhotoFromCollection(
-        @Path("collection_id") collection_id: Int,
+        @Path("collection_id") collection_id: String,
         @Query("photo_id") photo_id: String
     ): CollectionPhotoResult
 }

--- a/app/src/main/java/com/b_lam/resplash/data/collection/model/Collection.kt
+++ b/app/src/main/java/com/b_lam/resplash/data/collection/model/Collection.kt
@@ -10,7 +10,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @JsonClass(generateAdapter = true)
 data class Collection(
-    val id: Int,
+    val id: String,
     val title: String,
     val description: String?,
     val published_at: String?,

--- a/app/src/main/java/com/b_lam/resplash/data/photo/PhotoService.kt
+++ b/app/src/main/java/com/b_lam/resplash/data/photo/PhotoService.kt
@@ -23,7 +23,7 @@ interface PhotoService {
 
     @GET("photos/random")
     suspend fun getRandomPhotos(
-        @Query("collections") collectionsId: Int?,
+        @Query("collections") collectionsId: String?,
         @Query("featured") featured: Boolean?,
         @Query("username") username: String?,
         @Query("query") query: String?,

--- a/app/src/main/java/com/b_lam/resplash/di/StorageModule.kt
+++ b/app/src/main/java/com/b_lam/resplash/di/StorageModule.kt
@@ -2,6 +2,8 @@ package com.b_lam.resplash.di
 
 import android.app.Application
 import androidx.room.Room
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.b_lam.resplash.domain.login.AccessTokenProvider
 import com.b_lam.resplash.domain.SharedPreferencesRepository
 import com.b_lam.resplash.data.autowallpaper.AutoWallpaperDatabase
@@ -23,7 +25,68 @@ val storageModule = module {
     single { get<AutoWallpaperDatabase>().autoWallpaperCollectionDao() }
 }
 
+/**
+ * Migration changes:
+ *  - Upgrade `auto_wallpaper_collections` table due to change in `id` type (INTEGER -> TEXT).
+ */
+val MIGRATION_1_2 = object : Migration(1, 2) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        // Initiate db transaction.
+        database.execSQL("BEGIN TRANSACTION;")
+
+        // Create new auto_wallpaper_collections_upgrade table with updated schema.
+        database.execSQL("""
+            CREATE TABLE `auto_wallpaper_collections_upgrade` (
+                `id` TEXT NOT NULL,
+                `title` TEXT,
+                `user_name` TEXT,
+                `cover_photo` TEXT,
+                `date_added` INTEGER,
+                PRIMARY KEY(`id`)
+            );
+        """.trimIndent())
+
+        // Copy old auto_wallpaper_collections data into the newly created table.
+        database.execSQL("""
+            INSERT INTO `auto_wallpaper_collections_upgrade` (
+                id,
+                title,
+                user_name,
+                cover_photo,
+                date_added
+            )
+            SELECT
+                CAST (id AS TEXT),
+                title,
+                user_name,
+                cover_photo,
+                date_added
+            FROM `auto_wallpaper_collections`;
+        """.trimIndent())
+
+        // Remove old auto_wallpaper_collections table.
+        database.execSQL("DROP TABLE auto_wallpaper_collections;")
+
+        // Rename `auto_wallpaper_collections_upgrade` -> `auto_wallpaper_collections`.
+        database.execSQL("""
+            ALTER TABLE 'auto_wallpaper_collections_upgrade' RENAME TO 'auto_wallpaper_collections';
+        """.trimIndent())
+
+        // Create indices for `auto_wallpaper_collections`.
+        database.execSQL("""
+            CREATE INDEX `index_auto_wallpaper_collections_date_added`
+            ON `auto_wallpaper_collections` (
+                `date_added`
+            );
+        """.trimIndent())
+
+        // Commit changes to db.
+        database.execSQL("COMMIT;")
+    }
+}
+
 private fun createWallpaperDatabase(application: Application) =
     Room.databaseBuilder(application, AutoWallpaperDatabase::class.java, "auto_wallpaper_db")
+        .addMigrations(MIGRATION_1_2)
         .fallbackToDestructiveMigration()
         .build()

--- a/app/src/main/java/com/b_lam/resplash/domain/autowallpaper/AutoWallpaperRepository.kt
+++ b/app/src/main/java/com/b_lam/resplash/domain/autowallpaper/AutoWallpaperRepository.kt
@@ -49,14 +49,14 @@ class AutoWallpaperRepository(
         return autoWallpaperCollectionDao.getSelectedAutoWallpaperCollections()
     }
 
-    fun getSelectedAutoWallpaperCollectionIds(): LiveData<List<Int>> {
+    fun getSelectedAutoWallpaperCollectionIds(): LiveData<List<String>> {
         return autoWallpaperCollectionDao.getSelectedAutoWallpaperCollectionIds()
     }
 
     suspend fun removeCollectionFromAutoWallpaper(collection: Collection) =
         removeCollectionFromAutoWallpaper(collection.id)
 
-    suspend fun removeCollectionFromAutoWallpaper(id: Int) = withContext(Dispatchers.IO) {
+    suspend fun removeCollectionFromAutoWallpaper(id: String) = withContext(Dispatchers.IO) {
         autoWallpaperCollectionDao.delete(id)
     }
 
@@ -77,13 +77,13 @@ class AutoWallpaperRepository(
         )
     }
 
-    fun isCollectionUsedForAutoWallpaper(id: Int) =
+    fun isCollectionUsedForAutoWallpaper(id: String) =
         Transformations.map(autoWallpaperCollectionDao.getCountById(id)) { it > 0 }
 
     fun getNumberOfAutoWallpaperCollectionsLiveData() =
         autoWallpaperCollectionDao.getNumberOfAutoWallpaperCollectionsLiveData()
 
-    suspend fun getRandomAutoWallpaperCollectionId(): Int? {
+    suspend fun getRandomAutoWallpaperCollectionId(): String? {
         val count = autoWallpaperCollectionDao.getNumberOfAutoWallpaperCollections()
         return if (count > 0) {
             autoWallpaperCollectionDao.getRandomAutoWallpaperCollectionId((0 until count).random())

--- a/app/src/main/java/com/b_lam/resplash/domain/collection/CollectionRepository.kt
+++ b/app/src/main/java/com/b_lam/resplash/domain/collection/CollectionRepository.kt
@@ -46,21 +46,21 @@ class CollectionRepository(
             userService.getUserCollections(username, page, Properties.DEFAULT_PAGE_SIZE)
         }
 
-    suspend fun getCollection(collectionId: Int) =
+    suspend fun getCollection(collectionId: String) =
         safeApiCall(dispatcher) { collectionService.getCollection(collectionId) }
 
     suspend fun createCollection(title: String, description: String?, private: Boolean?) =
         safeApiCall(dispatcher) { collectionService.createCollection(title, description, private) }
 
-    suspend fun updateCollection(id: Int, title: String, description: String?, private: Boolean?) =
+    suspend fun updateCollection(id: String, title: String, description: String?, private: Boolean?) =
         safeApiCall(dispatcher) { collectionService.updateCollection(id, title, description, private) }
 
-    suspend fun deleteCollection(id: Int): Result<Response<Unit>> =
+    suspend fun deleteCollection(id: String): Result<Response<Unit>> =
         safeApiCall(dispatcher) { collectionService.deleteCollection(id) }
 
-    suspend fun addPhotoToCollection(collectionId: Int, photoId: String) =
+    suspend fun addPhotoToCollection(collectionId: String, photoId: String) =
         safeApiCall(dispatcher) { collectionService.addPhotoToCollection(collectionId, photoId) }
 
-    suspend fun removePhotoFromCollection(collectionId: Int, photoId: String) =
+    suspend fun removePhotoFromCollection(collectionId: String, photoId: String) =
         safeApiCall(dispatcher) { collectionService.removePhotoFromCollection(collectionId, photoId) }
 }

--- a/app/src/main/java/com/b_lam/resplash/domain/photo/CollectionPhotoDataSource.kt
+++ b/app/src/main/java/com/b_lam/resplash/domain/photo/CollectionPhotoDataSource.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.CoroutineScope
 
 class CollectionPhotoDataSource(
     private val collectionService: CollectionService,
-    private val collectionId: Int,
+    private val collectionId: String,
     scope: CoroutineScope
 ) : BaseDataSource<Photo>(scope) {
 

--- a/app/src/main/java/com/b_lam/resplash/domain/photo/CollectionPhotoDataSourceFactory.kt
+++ b/app/src/main/java/com/b_lam/resplash/domain/photo/CollectionPhotoDataSourceFactory.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.CoroutineScope
 
 class CollectionPhotoDataSourceFactory(
     private val collectionService: CollectionService,
-    private val collectionId: Int,
+    private val collectionId: String,
     private val scope: CoroutineScope
 ) : BaseDataSourceFactory<Photo>() {
 

--- a/app/src/main/java/com/b_lam/resplash/domain/photo/PhotoRepository.kt
+++ b/app/src/main/java/com/b_lam/resplash/domain/photo/PhotoRepository.kt
@@ -27,7 +27,7 @@ class PhotoRepository(
     }
 
     fun getCollectionPhotos(
-        collectionId: Int,
+        collectionId: String,
         scope: CoroutineScope
     ): Listing<Photo> {
         return CollectionPhotoDataSourceFactory(collectionService, collectionId, scope).createListing()
@@ -72,7 +72,7 @@ class PhotoRepository(
     suspend fun getPhotoDetails(id: String) = safeApiCall(dispatcher) { photoService.getPhoto(id) }
 
     suspend fun getRandomPhoto(
-        collectionId: Int? = null,
+        collectionId: String? = null,
         featured: Boolean? = false,
         username: String? = null,
         query: String? = null,
@@ -84,7 +84,7 @@ class PhotoRepository(
     }
 
     suspend fun getRandomPhotos(
-        collectionId: Int? = null,
+        collectionId: String? = null,
         featured: Boolean? = false,
         username: String? = null,
         query: String? = null,

--- a/app/src/main/java/com/b_lam/resplash/ui/autowallpaper/collections/AddAutoWallpaperCollectionBottomSheet.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/autowallpaper/collections/AddAutoWallpaperCollectionBottomSheet.kt
@@ -75,8 +75,8 @@ class AddAutoWallpaperCollectionBottomSheet : BottomSheetDialogFragment() {
 
     private fun isCollectionUrlValid(url: String) = urlRegex matches url
 
-    private fun extractCollectionIdFromUrl(url: String): Int? {
-        return urlRegex.find(url)?.destructured?.let { (id) -> id.toInt() }
+    private fun extractCollectionIdFromUrl(url: String): String? {
+        return urlRegex.find(url)?.destructured?.let { (id) -> id }
     }
 
     companion object {

--- a/app/src/main/java/com/b_lam/resplash/ui/autowallpaper/collections/AutoWallpaperCollectionListAdapter.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/autowallpaper/collections/AutoWallpaperCollectionListAdapter.kt
@@ -13,7 +13,7 @@ class AutoWallpaperCollectionListAdapter(
     private val callback: ItemEventCallback
 ) : ListAdapter<AutoWallpaperCollection, RecyclerView.ViewHolder>(diffCallback) {
 
-    private var selectedCollectionIds = listOf<Int>()
+    private var selectedCollectionIds = listOf<String>()
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
@@ -53,7 +53,7 @@ class AutoWallpaperCollectionListAdapter(
         ItemType.POPULAR -> R.layout.item_auto_wallpaper_popular_collection
     }
 
-    fun setSelectedCollectionIds(selectedCollectionIds: List<Int>) {
+    fun setSelectedCollectionIds(selectedCollectionIds: List<String>) {
         this.selectedCollectionIds = selectedCollectionIds
         notifyDataSetChanged()
     }
@@ -66,9 +66,9 @@ class AutoWallpaperCollectionListAdapter(
 
     interface ItemEventCallback {
 
-        fun onCollectionClick(id: Int)
+        fun onCollectionClick(id: String)
         fun onAddClick(collection: AutoWallpaperCollection)
-        fun onRemoveClick(id: Int)
+        fun onRemoveClick(id: String)
     }
 
     companion object {

--- a/app/src/main/java/com/b_lam/resplash/ui/autowallpaper/collections/AutoWallpaperCollectionViewModel.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/autowallpaper/collections/AutoWallpaperCollectionViewModel.kt
@@ -87,13 +87,13 @@ class AutoWallpaperCollectionViewModel(
         }
     }
 
-    fun removeAutoWallpaperCollection(id: Int) {
+    fun removeAutoWallpaperCollection(id: String) {
         viewModelScope.launch {
             autoWallpaperRepository.removeCollectionFromAutoWallpaper(id)
         }
     }
 
-    fun getCollectionDetailsAndAdd(id: Int) {
+    fun getCollectionDetailsAndAdd(id: String) {
         viewModelScope.launch {
             val result = collectionRepository.getCollection(id)
             if (result is Result.Success) {

--- a/app/src/main/java/com/b_lam/resplash/ui/autowallpaper/collections/DiscoverAutoWallpaperCollectionFragment.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/autowallpaper/collections/DiscoverAutoWallpaperCollectionFragment.kt
@@ -63,7 +63,7 @@ class DiscoverAutoWallpaperCollectionFragment :
         }
     }
 
-    override fun onCollectionClick(id: Int) {
+    override fun onCollectionClick(id: String) {
         Intent(context, CollectionDetailActivity::class.java).apply {
             putExtra(CollectionDetailActivity.EXTRA_COLLECTION_ID, id.toString())
             startActivity(this)
@@ -75,7 +75,7 @@ class DiscoverAutoWallpaperCollectionFragment :
         binding.root.showSnackBar(R.string.auto_wallpaper_collection_added)
     }
 
-    override fun onRemoveClick(id: Int) {
+    override fun onRemoveClick(id: String) {
         sharedViewModel.removeAutoWallpaperCollection(id)
         binding.root.showSnackBar(R.string.auto_wallpaper_collection_removed)
     }

--- a/app/src/main/java/com/b_lam/resplash/ui/autowallpaper/collections/FeaturedAutoWallpaperCollectionViewHolder.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/autowallpaper/collections/FeaturedAutoWallpaperCollectionViewHolder.kt
@@ -14,7 +14,7 @@ class FeaturedAutoWallpaperCollectionViewHolder(parent: View) : RecyclerView.Vie
 
     fun bind(
         collection: AutoWallpaperCollection?,
-        selectedCollectionIds: List<Int>,
+        selectedCollectionIds: List<String>,
         callback: AutoWallpaperCollectionListAdapter.ItemEventCallback
     ) {
         with(binding) {
@@ -23,7 +23,7 @@ class FeaturedAutoWallpaperCollectionViewHolder(parent: View) : RecyclerView.Vie
                 userNameTextView.text = itemView.context.getString(R.string.curated_by_template, collection.user_name)
                 collection.cover_photo?.let { collectionImageView.loadPhotoUrl(it) }
                 collectionCardView.setOnClickListener {
-                    collection.id?.let { id -> callback.onCollectionClick(id) }
+                    callback.onCollectionClick(collection.id)
                 }
                 val isCollectionSelected = selectedCollectionIds.contains(collection.id)
                 addButton.setImageResource(
@@ -35,7 +35,7 @@ class FeaturedAutoWallpaperCollectionViewHolder(parent: View) : RecyclerView.Vie
                 )
                 addButton.setOnClickListener {
                     if (isCollectionSelected) {
-                        collection.id?.let { id -> callback.onRemoveClick(id) }
+                        callback.onRemoveClick(collection.id)
                     } else {
                         callback.onAddClick(collection)
                     }

--- a/app/src/main/java/com/b_lam/resplash/ui/autowallpaper/collections/PopularAutoWallpaperCollectionViewHolder.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/autowallpaper/collections/PopularAutoWallpaperCollectionViewHolder.kt
@@ -14,7 +14,7 @@ class PopularAutoWallpaperCollectionViewHolder(parent: View) : RecyclerView.View
 
     fun bind(
         collection: AutoWallpaperCollection?,
-        selectedCollectionIds: List<Int>,
+        selectedCollectionIds: List<String>,
         callback: AutoWallpaperCollectionListAdapter.ItemEventCallback
     ) {
         with(binding) {
@@ -23,7 +23,7 @@ class PopularAutoWallpaperCollectionViewHolder(parent: View) : RecyclerView.View
                 userNameTextView.text = itemView.context.getString(R.string.curated_by_template, collection.user_name)
                 collection.cover_photo?.let { collectionImageView.loadPhotoUrl(it) }
                 collectionCardView.setOnClickListener {
-                    collection.id?.let { id -> callback.onCollectionClick(id) }
+                    callback.onCollectionClick(collection.id)
                 }
                 val isCollectionSelected = selectedCollectionIds.contains(collection.id)
                 addButton.setImageResource(
@@ -35,7 +35,7 @@ class PopularAutoWallpaperCollectionViewHolder(parent: View) : RecyclerView.View
                 )
                 addButton.setOnClickListener {
                     if (isCollectionSelected) {
-                        collection.id?.let { id -> callback.onRemoveClick(id) }
+                        callback.onRemoveClick(collection.id)
                     } else {
                         callback.onAddClick(collection)
                     }

--- a/app/src/main/java/com/b_lam/resplash/ui/autowallpaper/collections/SelectedAutoWallpaperCollectionFragment.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/autowallpaper/collections/SelectedAutoWallpaperCollectionFragment.kt
@@ -49,7 +49,7 @@ class SelectedAutoWallpaperCollectionFragment :
         setEmptyStateText()
     }
 
-    override fun onCollectionClick(id: Int) {
+    override fun onCollectionClick(id: String) {
         Intent(context, CollectionDetailActivity::class.java).apply {
             putExtra(CollectionDetailActivity.EXTRA_COLLECTION_ID, id.toString())
             startActivity(this)
@@ -60,7 +60,7 @@ class SelectedAutoWallpaperCollectionFragment :
         // Do nothing
     }
 
-    override fun onRemoveClick(id: Int) {
+    override fun onRemoveClick(id: String) {
         sharedViewModel.removeAutoWallpaperCollection(id)
         binding.recyclerView.showSnackBar(R.string.auto_wallpaper_collection_removed)
     }

--- a/app/src/main/java/com/b_lam/resplash/ui/autowallpaper/collections/SelectedAutoWallpaperCollectionViewHolder.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/autowallpaper/collections/SelectedAutoWallpaperCollectionViewHolder.kt
@@ -20,10 +20,10 @@ class SelectedAutoWallpaperCollectionViewHolder(parent: View) : RecyclerView.Vie
                 collectionNameTextView.text = collection.title
                 collection.cover_photo?.let { collectionImageView.loadPhotoUrl(it) }
                 collectionCardView.setOnClickListener {
-                    collection.id?.let { id -> callback.onCollectionClick(id) }
+                    callback.onCollectionClick(collection.id)
                 }
                 removeButton.setOnClickListener {
-                    collection.id?.let { id -> callback.onRemoveClick(id) }
+                    callback.onRemoveClick(collection.id)
                 }
             }
         }

--- a/app/src/main/java/com/b_lam/resplash/ui/collection/add/AddCollectionAdapter.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/collection/add/AddCollectionAdapter.kt
@@ -12,7 +12,7 @@ class AddCollectionAdapter(
     private val callback: ItemEventCallback
 ) : ListAdapter<Collection, MiniCollectionViewHolder>(diffCallback) {
 
-    private var currentUserCollectionIds: List<Int>? = null
+    private var currentUserCollectionIds: List<String>? = null
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MiniCollectionViewHolder {
         val view = LayoutInflater.from(parent.context)
@@ -24,7 +24,7 @@ class AddCollectionAdapter(
         holder.bind(getItem(position), currentUserCollectionIds, callback)
     }
 
-    fun setCurrentUserCollectionIds(currentUserCollectionIds: List<Int>?) {
+    fun setCurrentUserCollectionIds(currentUserCollectionIds: List<String>?) {
         this.currentUserCollectionIds = currentUserCollectionIds
     }
 

--- a/app/src/main/java/com/b_lam/resplash/ui/collection/add/MiniCollectionViewHolder.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/collection/add/MiniCollectionViewHolder.kt
@@ -17,7 +17,7 @@ class MiniCollectionViewHolder(parent: View) : RecyclerView.ViewHolder(parent) {
 
     fun bind(
         collection: Collection?,
-        currentUserCollectionIds: List<Int>?,
+        currentUserCollectionIds: List<String>?,
         callback: AddCollectionAdapter.ItemEventCallback
     ) {
         with(binding) {

--- a/app/src/main/java/com/b_lam/resplash/ui/collection/detail/CollectionDetailActivity.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/collection/detail/CollectionDetailActivity.kt
@@ -42,7 +42,7 @@ class CollectionDetailActivity : BaseActivity(R.layout.activity_collection_detai
 
         when {
             collection != null -> viewModel.setCollection(collection)
-            collectionId != null -> viewModel.getCollection(collectionId.toInt())
+            collectionId != null -> viewModel.getCollection(collectionId)
             else -> finish()
         }
 

--- a/app/src/main/java/com/b_lam/resplash/ui/collection/detail/CollectionDetailViewModel.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/collection/detail/CollectionDetailViewModel.kt
@@ -40,13 +40,13 @@ class CollectionDetailViewModel(
     val networkStateLiveData = Transformations.switchMap(photoListing) { it.networkState }
     val refreshStateLiveData = Transformations.switchMap(photoListing) { it.refreshState }
 
-    fun getPhotoListing(collectionId: Int) {
+    fun getPhotoListing(collectionId: String) {
         photoListing.postValue(photoRepository.getCollectionPhotos(collectionId, viewModelScope))
     }
 
     fun refreshPhotos() = photoListing.value?.refresh?.invoke()
 
-    fun getCollection(collectionId: Int) {
+    fun getCollection(collectionId: String) {
         viewModelScope.launch {
             val result = collectionRepository.getCollection(collectionId)
             if (result is Result.Success) {
@@ -60,7 +60,7 @@ class CollectionDetailViewModel(
 
     fun isOwnCollection() = collectionLiveData.value?.user?.username == loginRepository.getUsername()
 
-    fun isCollectionUsedForAutoWallpaper(id: Int) =
+    fun isCollectionUsedForAutoWallpaper(id: String) =
         autoWallpaperRepository.isCollectionUsedForAutoWallpaper(id)
 
     fun addCollectionToAutoWallpaper() {

--- a/app/src/main/java/com/b_lam/resplash/ui/photo/detail/PhotoDetailActivity.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/photo/detail/PhotoDetailActivity.kt
@@ -243,7 +243,7 @@ class PhotoDetailActivity :
         )
     }
 
-    private fun setCollectButtonState(currentUserCollectionIds: List<Int>) {
+    private fun setCollectButtonState(currentUserCollectionIds: List<String>) {
         binding.collectButton.setImageResource(
             if (currentUserCollectionIds.isNotEmpty()) R.drawable.ic_bookmark_filled_24dp
             else R.drawable.ic_bookmark_border_24dp

--- a/app/src/main/java/com/b_lam/resplash/ui/photo/detail/PhotoDetailViewModel.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/photo/detail/PhotoDetailViewModel.kt
@@ -34,8 +34,8 @@ class PhotoDetailViewModel(
         return@lazyMap liveData
     }
 
-    private val _currentUserCollectionIds = MutableLiveData<MutableList<Int>?>()
-    val currentUserCollectionIds: LiveData<MutableList<Int>?> = _currentUserCollectionIds
+    private val _currentUserCollectionIds = MutableLiveData<MutableList<String>?>()
+    val currentUserCollectionIds: LiveData<MutableList<String>?> = _currentUserCollectionIds
 
     private val _userCollections = MutableLiveData<MutableList<Collection>?>()
     val userCollections: LiveData<MutableList<Collection>?> = _userCollections
@@ -51,7 +51,7 @@ class PhotoDetailViewModel(
 
     fun isUserAuthorized() = loginRepository.isAuthorized()
 
-    fun addPhotoToCollection(collectionId: Int, photoId: String, position: Int) =
+    fun addPhotoToCollection(collectionId: String, photoId: String, position: Int) =
         liveData(viewModelScope.coroutineContext) {
             emit(Result.Loading)
 
@@ -69,7 +69,7 @@ class PhotoDetailViewModel(
             emit(result)
         }
 
-    fun removePhotoFromCollection(collectionId: Int, photoId: String, position: Int) =
+    fun removePhotoFromCollection(collectionId: String, photoId: String, position: Int) =
         liveData(viewModelScope.coroutineContext) {
             emit(Result.Loading)
 

--- a/app/src/main/java/com/b_lam/resplash/ui/upgrade/UpgradeViewModel.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/upgrade/UpgradeViewModel.kt
@@ -53,6 +53,6 @@ class UpgradeViewModel(
 
     companion object {
 
-        private const val RESPLASH_COLLECTION_ID = 10548247
+        private const val RESPLASH_COLLECTION_ID = "10548247"
     }
 }


### PR DESCRIPTION
Looks like Unsplash API has upgraded its collections API's schema. It has changed **id** type from **int** to **string**. Due to this change, the App's collection features were breaking. 

**PR Changelog:**
- Upgraded collection id from **int** to **string** in all touchpoints in the App. This fixes the JSON parsing issue.
- Migrate **auto_wallpaper_collections** table in order to retain old data with this upgrade.

**Fixes:** #130 