### PR TITLE
fix: bitmap wallpaper setting on main thread

### DIFF
--- a/app/src/main/java/com/b_lam/resplash/di/ManagerModule.kt
+++ b/app/src/main/java/com/b_lam/resplash/di/ManagerModule.kt
@@ -1,7 +1,9 @@
 package com.b_lam.resplash.di
 
+import android.app.WallpaperManager
 import com.b_lam.resplash.util.NotificationManager
 import com.b_lam.resplash.util.download.DownloadManagerWrapper
+import org.koin.android.ext.koin.androidApplication
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
@@ -9,4 +11,5 @@ val managerModule = module {
 
     single(createdAtStart = true) { NotificationManager(androidContext()) }
     single { DownloadManagerWrapper(androidContext()) }
+    single { WallpaperManager.getInstance(androidApplication()) }
 }

--- a/app/src/main/java/com/b_lam/resplash/ui/photo/detail/PhotoDetailActivity.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/photo/detail/PhotoDetailActivity.kt
@@ -274,7 +274,10 @@ class PhotoDetailActivity :
             } else {
                 viewModel.downloadUUID = DownloadWorker.enqueueDownload(
                     applicationContext,
-                    DownloadAction.DOWNLOAD, url, photo.fileName, photo.id
+                    DownloadAction.DOWNLOAD,
+                    url,
+                    photo.fileName,
+                    photo.id
                 )
             }
         } else {

--- a/app/src/main/java/com/b_lam/resplash/ui/photo/detail/PhotoDetailActivity.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/photo/detail/PhotoDetailActivity.kt
@@ -37,6 +37,8 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.*
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import java.io.IOException
+import java.lang.Exception
 import java.util.concurrent.Executors
 
 class PhotoDetailActivity :
@@ -361,11 +363,20 @@ class PhotoDetailActivity :
 
     private fun setWallpaperWithBitmap(bitmap: Bitmap) {
         lifecycleScope.launch {
+            var isWallpaperSet = false
             withContext((Executors.newSingleThreadExecutor().asCoroutineDispatcher())) {
-                wallpaperManager.setBitmap(bitmap)
+                try {
+                    wallpaperManager.setBitmap(bitmap)
+                    isWallpaperSet = true
+                } catch (exception: IOException) {
+                    error("Error setting wallpaper bitmap: $exception")
+                }
             }
             withContext(Dispatchers.Main) {
-                this@PhotoDetailActivity.toast("Wallpaper set successfully")
+                val resultMessage = if (isWallpaperSet) {
+                    "Wallpaper set successfully"
+                } else "Error setting wallpaper"
+                this@PhotoDetailActivity.toast(resultMessage)
             }
         }
     }

--- a/app/src/main/java/com/b_lam/resplash/ui/photo/detail/PhotoDetailActivity.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/photo/detail/PhotoDetailActivity.kt
@@ -291,7 +291,10 @@ class PhotoDetailActivity :
             } else {
                 viewModel.downloadUUID = DownloadWorker.enqueueDownload(
                     applicationContext,
-                    DownloadAction.WALLPAPER, url, photo.fileName, photo.id
+                    DownloadAction.WALLPAPER,
+                    url,
+                    photo.fileName,
+                    photo.id
                 )
             }
 

--- a/app/src/main/java/com/b_lam/resplash/ui/photo/detail/PhotoDetailActivity.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/photo/detail/PhotoDetailActivity.kt
@@ -31,6 +31,7 @@ import com.b_lam.resplash.ui.user.UserActivity
 import com.b_lam.resplash.ui.widget.recyclerview.SpacingItemDecoration
 import com.b_lam.resplash.util.*
 import com.b_lam.resplash.util.download.*
+import com.b_lam.resplash.util.livedata.observeOnce
 import com.b_lam.resplash.worker.DownloadWorker
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
@@ -351,7 +352,7 @@ class PhotoDetailActivity :
     }
 
     private fun observeWallpaperBitmapResult() {
-        viewModel.wallpaperBitmap.observe(this) { result ->
+        viewModel.wallpaperBitmap.observeOnce(this) { result ->
             if (result is Result.Success) {
                 setWallpaperWithBitmap(result.value)
             } else {

--- a/app/src/main/java/com/b_lam/resplash/ui/photo/detail/PhotoDetailActivity.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/photo/detail/PhotoDetailActivity.kt
@@ -38,7 +38,6 @@ import kotlinx.coroutines.*
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import java.io.IOException
-import java.lang.Exception
 import java.util.concurrent.Executors
 
 class PhotoDetailActivity :
@@ -347,11 +346,11 @@ class PhotoDetailActivity :
             startActivity(wallpaperManager.getCropAndSetWallpaperIntent(uri))
         } catch (e: IllegalArgumentException) {
             viewModel.prepareBitmapFromUri(contentResolver, uri)
-            observerWallpaperBitmapResult()
+            observeWallpaperBitmapResult()
         }
     }
 
-    private fun observerWallpaperBitmapResult() {
+    private fun observeWallpaperBitmapResult() {
         viewModel.wallpaperBitmap.observe(this) { result ->
             if (result is Result.Success) {
                 setWallpaperWithBitmap(result.value)
@@ -364,7 +363,7 @@ class PhotoDetailActivity :
     private fun setWallpaperWithBitmap(bitmap: Bitmap) {
         lifecycleScope.launch {
             var isWallpaperSet = false
-            withContext((Executors.newSingleThreadExecutor().asCoroutineDispatcher())) {
+            withContext(Executors.newSingleThreadExecutor().asCoroutineDispatcher()) {
                 try {
                     wallpaperManager.setBitmap(bitmap)
                     isWallpaperSet = true
@@ -375,7 +374,9 @@ class PhotoDetailActivity :
             withContext(Dispatchers.Main) {
                 val resultMessage = if (isWallpaperSet) {
                     "Wallpaper set successfully"
-                } else "Error setting wallpaper"
+                } else  {
+                    "Error setting wallpaper"
+                }
                 this@PhotoDetailActivity.toast(resultMessage)
             }
         }


### PR DESCRIPTION
Presently, when the `Wallapaper Manager` is unable to find the crop and set activity. App decodes the image and sets the bitmap on the main thread which should be avoided.  