### PR TITLE
Auto Wallpaper Persistent Notification

### DIFF
--- a/app/src/main/java/com/b_lam/resplash/di/WorkerModule.kt
+++ b/app/src/main/java/com/b_lam/resplash/di/WorkerModule.kt
@@ -24,7 +24,8 @@ val workerModule = module {
         FutureAutoWallpaperWorker(
             context = get(),
             params = workerParams,
-            sharedPreferencesRepository = get()
+            sharedPreferencesRepository = get(),
+            notificationManager = get()
         )
     }
     worker { (workerParams: WorkerParameters) ->

--- a/app/src/main/java/com/b_lam/resplash/domain/SharedPreferencesRepository.kt
+++ b/app/src/main/java/com/b_lam/resplash/domain/SharedPreferencesRepository.kt
@@ -99,6 +99,11 @@ class SharedPreferencesRepository(context: Context) {
             PREFERENCE_AUTO_WALLPAPER_SHOW_NOTIFICATION_KEY,
             PREFERENCE_AUTO_WALLPAPER_SHOW_NOTIFICATION_DEFAULT_VALUE)
 
+    val autoWallpaperPersistNotification: Boolean
+        get() = sharedPreferences.getBoolean(
+            PREFERENCE_AUTO_WALLPAPER_PERSIST_NOTIFICATION_KEY,
+            PREFERENCE_AUTO_WALLPAPER_PERSIST_NOTIFICATION_DEFAULT_VALUE)
+
     val autoWallpaperPortraitModeOnly: Boolean
         get() = sharedPreferences.getBoolean(
             PREFERENCE_AUTO_WALLPAPER_PORTRAIT_MODE_ONLY_KEY,
@@ -228,6 +233,9 @@ class SharedPreferencesRepository(context: Context) {
 
         private const val PREFERENCE_AUTO_WALLPAPER_SHOW_NOTIFICATION_KEY = "auto_wallpaper_show_notification"
         private const val PREFERENCE_AUTO_WALLPAPER_SHOW_NOTIFICATION_DEFAULT_VALUE = true
+
+        private const val PREFERENCE_AUTO_WALLPAPER_PERSIST_NOTIFICATION_KEY = "auto_wallpaper_persist_notification"
+        private const val PREFERENCE_AUTO_WALLPAPER_PERSIST_NOTIFICATION_DEFAULT_VALUE = true
 
         private const val PREFERENCE_AUTO_WALLPAPER_PORTRAIT_MODE_ONLY_KEY = "auto_wallpaper_portrait_mode_only"
         private const val PREFERENCE_AUTO_WALLPAPER_PORTRAIT_MODE_ONLY_DEFAULT_VALUE = false

--- a/app/src/main/java/com/b_lam/resplash/domain/SharedPreferencesRepository.kt
+++ b/app/src/main/java/com/b_lam/resplash/domain/SharedPreferencesRepository.kt
@@ -235,7 +235,7 @@ class SharedPreferencesRepository(context: Context) {
         private const val PREFERENCE_AUTO_WALLPAPER_SHOW_NOTIFICATION_DEFAULT_VALUE = true
 
         private const val PREFERENCE_AUTO_WALLPAPER_PERSIST_NOTIFICATION_KEY = "auto_wallpaper_persist_notification"
-        private const val PREFERENCE_AUTO_WALLPAPER_PERSIST_NOTIFICATION_DEFAULT_VALUE = true
+        private const val PREFERENCE_AUTO_WALLPAPER_PERSIST_NOTIFICATION_DEFAULT_VALUE = false
 
         private const val PREFERENCE_AUTO_WALLPAPER_PORTRAIT_MODE_ONLY_KEY = "auto_wallpaper_portrait_mode_only"
         private const val PREFERENCE_AUTO_WALLPAPER_PORTRAIT_MODE_ONLY_DEFAULT_VALUE = false

--- a/app/src/main/java/com/b_lam/resplash/provider/AutoWallpaperAppWidgetProvider.kt
+++ b/app/src/main/java/com/b_lam/resplash/provider/AutoWallpaperAppWidgetProvider.kt
@@ -9,6 +9,7 @@ import android.widget.RemoteViews
 import com.b_lam.resplash.R
 import com.b_lam.resplash.domain.SharedPreferencesRepository
 import com.b_lam.resplash.ui.autowallpaper.AutoWallpaperSettingsActivity
+import com.b_lam.resplash.util.NotificationManager
 import com.b_lam.resplash.util.toast
 import com.b_lam.resplash.worker.AutoWallpaperWorker
 import org.koin.core.component.KoinComponent
@@ -20,13 +21,13 @@ class AutoWallpaperAppWidgetProvider : AppWidgetProvider(), KoinComponent {
         super.onReceive(context, intent)
 
         val sharedPreferencesRepository: SharedPreferencesRepository by inject()
+        val notificationManager: NotificationManager by inject()
 
         if (context != null && intent?.action == ACTION_WIDGET_NEXT) {
             with(context) {
                 if (sharedPreferencesRepository.autoWallpaperEnabled) {
                     toast(R.string.setting_wallpaper)
-                    AutoWallpaperWorker.scheduleSingleAutoWallpaperJob(
-                        this, sharedPreferencesRepository)
+                    AutoWallpaperWorker.scheduleSingleAutoWallpaperJob(this, sharedPreferencesRepository, notificationManager)
                 } else {
                     toast("Auto Wallpaper is not enabled")
                     Intent(this, AutoWallpaperSettingsActivity::class.java).apply {

--- a/app/src/main/java/com/b_lam/resplash/service/AutoWallpaperTileService.kt
+++ b/app/src/main/java/com/b_lam/resplash/service/AutoWallpaperTileService.kt
@@ -35,7 +35,7 @@ class AutoWallpaperTileService: TileService(), LifecycleOwner, KoinComponent {
             when (it.state) {
                 Tile.STATE_ACTIVE -> {
                     notificationManager.showTileServiceDownloadingNotification()
-                    AutoWallpaperWorker.scheduleSingleAutoWallpaperJob(this@AutoWallpaperTileService, get())
+                    AutoWallpaperWorker.scheduleSingleAutoWallpaperJob(this@AutoWallpaperTileService, get(), get())
                 }
                 else -> unlockAndRun {
                     Intent(this@AutoWallpaperTileService, AutoWallpaperSettingsActivity::class.java).apply {

--- a/app/src/main/java/com/b_lam/resplash/ui/autowallpaper/AutoWallpaperSettingsActivity.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/autowallpaper/AutoWallpaperSettingsActivity.kt
@@ -78,7 +78,7 @@ class AutoWallpaperSettingsActivity :
             }
 
         binding.nextFab.setOnClickListener {
-            AutoWallpaperWorker.scheduleSingleAutoWallpaperJob(this, sharedPreferencesRepository)
+            AutoWallpaperWorker.scheduleSingleAutoWallpaperJob(this, sharedPreferencesRepository, notificationManager)
         }
 
         if (isInstalledOnExternalStorage()) {
@@ -162,6 +162,7 @@ class AutoWallpaperSettingsActivity :
         private val sharedViewModel: AutoWallpaperSettingsViewModel by sharedViewModel()
 
         private val sharedPreferencesRepository: SharedPreferencesRepository by inject()
+        private val notificationManager: NotificationManager by inject()
 
         override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
             setPreferencesFromResource(R.xml.auto_wallpaper_preferences, rootKey)
@@ -281,7 +282,7 @@ class AutoWallpaperSettingsActivity :
         override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
             if (key?.contains("auto_wallpaper") == true) {
                 context?.let {
-                    AutoWallpaperWorker.scheduleAutoWallpaperJob(it, sharedPreferencesRepository)
+                    AutoWallpaperWorker.scheduleAutoWallpaperJob(it, sharedPreferencesRepository, notificationManager)
                 }
             }
         }

--- a/app/src/main/java/com/b_lam/resplash/ui/base/BaseActivity.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/base/BaseActivity.kt
@@ -15,6 +15,7 @@ import androidx.viewbinding.ViewBinding
 import com.b_lam.resplash.R
 import com.b_lam.resplash.domain.SharedPreferencesRepository
 import com.b_lam.resplash.ui.main.MainActivity
+import com.b_lam.resplash.util.NotificationManager
 import com.b_lam.resplash.util.applyLanguage
 import com.b_lam.resplash.util.getThemeAttrColor
 import org.koin.android.ext.android.inject
@@ -26,6 +27,7 @@ abstract class BaseActivity(@LayoutRes contentLayoutId: Int) : AppCompatActivity
     abstract val binding: ViewBinding
 
     val sharedPreferencesRepository: SharedPreferencesRepository by inject()
+    val notificationManager: NotificationManager by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/b_lam/resplash/util/NotificationManager.kt
+++ b/app/src/main/java/com/b_lam/resplash/util/NotificationManager.kt
@@ -111,7 +111,8 @@ class NotificationManager(private val context: Context) {
         id: String,
         title: String?,
         subtitle: String?,
-        previewUrl: String?
+        previewUrl: String?,
+        persist: Boolean?
     ) {
         val builder = NotificationCompat.Builder(context, NEW_AUTO_WALLPAPER_CHANNEL_ID).apply {
             priority = NotificationCompat.PRIORITY_MIN
@@ -126,6 +127,7 @@ class NotificationManager(private val context: Context) {
                 GlideApp.with(context).clear(futureTarget)
             }
         }
+        builder.setOngoing(persist == true)
         notificationManager.notify(NEW_AUTO_WALLPAPER_NOTIFICATION_ID, builder.build())
     }
 

--- a/app/src/main/java/com/b_lam/resplash/util/NotificationManager.kt
+++ b/app/src/main/java/com/b_lam/resplash/util/NotificationManager.kt
@@ -112,13 +112,13 @@ class NotificationManager(private val context: Context) {
         title: String?,
         subtitle: String?,
         previewUrl: String?,
-        persist: Boolean?
+        persist: Boolean
     ) {
         val builder = NotificationCompat.Builder(context, NEW_AUTO_WALLPAPER_CHANNEL_ID).apply {
             priority = NotificationCompat.PRIORITY_MIN
             setSmallIcon(R.drawable.ic_resplash_24dp)
             setContentIntent(getCurrentWallpaperPendingIntent(id))
-            setAutoCancel(true)
+            setAutoCancel(persist)
             title?.let { setContentTitle(it) }
             subtitle?.let { setContentText(it) }
             previewUrl?.let {
@@ -126,8 +126,8 @@ class NotificationManager(private val context: Context) {
                 setLargeIcon(futureTarget.get())
                 GlideApp.with(context).clear(futureTarget)
             }
+            setOngoing(persist)
         }
-        builder.setOngoing(persist == true)
         notificationManager.notify(NEW_AUTO_WALLPAPER_NOTIFICATION_ID, builder.build())
     }
 

--- a/app/src/main/java/com/b_lam/resplash/util/NotificationManager.kt
+++ b/app/src/main/java/com/b_lam/resplash/util/NotificationManager.kt
@@ -131,6 +131,10 @@ class NotificationManager(private val context: Context) {
         notificationManager.notify(NEW_AUTO_WALLPAPER_NOTIFICATION_ID, builder.build())
     }
 
+    fun hideNewAutoWallpaperNotification() {
+        notificationManager.cancel(NEW_AUTO_WALLPAPER_NOTIFICATION_ID)
+    }
+
     fun isNewAutoWallpaperNotificationEnabled(preferenceValue: Boolean): Boolean {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = notificationManager.getNotificationChannel(NEW_AUTO_WALLPAPER_CHANNEL_ID)

--- a/app/src/main/java/com/b_lam/resplash/worker/AutoWallpaperWorker.kt
+++ b/app/src/main/java/com/b_lam/resplash/worker/AutoWallpaperWorker.kt
@@ -235,7 +235,8 @@ class AutoWallpaperWorker(
         //Schedule wallpaper to change now regardless of conditions and schedule future change
         fun scheduleSingleAutoWallpaperJob(
             context: Context,
-            sharedPreferencesRepository: SharedPreferencesRepository
+            sharedPreferencesRepository: SharedPreferencesRepository,
+            notificationManager: NotificationManager
         ) {
             with(sharedPreferencesRepository) {
                 if (autoWallpaperEnabled) {
@@ -264,7 +265,7 @@ class AutoWallpaperWorker(
                         requestFuture
                     )
                 } else {
-                    cancelAllWork(context)
+                    cancelAllWork(context, notificationManager)
                 }
             }
         }
@@ -272,7 +273,8 @@ class AutoWallpaperWorker(
         //Schedule wallpaper to change with configured conditions
         fun scheduleAutoWallpaperJob(
             context: Context,
-            sharedPreferencesRepository: SharedPreferencesRepository
+            sharedPreferencesRepository: SharedPreferencesRepository,
+            notificationManager: NotificationManager
         ) {
             with(sharedPreferencesRepository) {
                 if (autoWallpaperEnabled) {
@@ -298,7 +300,7 @@ class AutoWallpaperWorker(
                         request
                     )
                 } else {
-                    cancelAllWork(context)
+                    cancelAllWork(context, notificationManager)
                 }
             }
         }
@@ -320,10 +322,11 @@ class AutoWallpaperWorker(
             KEY_AUTO_WALLPAPER_CONTENT_FILTER to sharedPreferencesRepository.autoWallpaperContentFilter
         )
 
-        private fun cancelAllWork(context: Context) {
+        private fun cancelAllWork(context: Context, notificationManager: NotificationManager) {
             WorkManager.getInstance(context).cancelUniqueWork(AUTO_WALLPAPER_SINGLE_JOB_ID)
             WorkManager.getInstance(context).cancelUniqueWork(AUTO_WALLPAPER_FUTURE_JOB_ID)
             WorkManager.getInstance(context).cancelUniqueWork(AUTO_WALLPAPER_JOB_ID)
+            notificationManager.hideNewAutoWallpaperNotification()
         }
     }
 }
@@ -331,11 +334,12 @@ class AutoWallpaperWorker(
 class FutureAutoWallpaperWorker(
     private val context: Context,
     params: WorkerParameters,
-    private val sharedPreferencesRepository: SharedPreferencesRepository
+    private val sharedPreferencesRepository: SharedPreferencesRepository,
+    private val notificationManager: NotificationManager
 ) : Worker(context, params) {
 
     override fun doWork(): Result {
-        AutoWallpaperWorker.scheduleAutoWallpaperJob(context, sharedPreferencesRepository)
+        AutoWallpaperWorker.scheduleAutoWallpaperJob(context, sharedPreferencesRepository, notificationManager)
         return Result.success()
     }
 }

--- a/app/src/main/java/com/b_lam/resplash/worker/AutoWallpaperWorker.kt
+++ b/app/src/main/java/com/b_lam/resplash/worker/AutoWallpaperWorker.kt
@@ -193,7 +193,12 @@ class AutoWallpaperWorker(
         val title = photo.description ?: photo.alt_description?.capitalize() ?: "Untitled"
         val subtitle = photo.user?.name
         notificationManager.showNewAutoWallpaperNotification(
-            photo.id, title, subtitle, photo.urls.thumb)
+            photo.id,
+            title,
+            subtitle,
+            photo.urls.thumb,
+            inputData.getBoolean(KEY_AUTO_WALLPAPER_PERSIST_NOTIFICATION, false)
+        )
     }
 
     companion object {
@@ -209,6 +214,7 @@ class AutoWallpaperWorker(
         private const val KEY_AUTO_WALLPAPER_SEARCH_TERMS = "key_auto_wallpaper_search_terms"
         private const val KEY_AUTO_WALLPAPER_CROP = "key_auto_wallpaper_crop"
         private const val KEY_AUTO_WALLPAPER_SHOW_NOTIFICATION = "key_auto_wallpaper_show_notification"
+        private const val KEY_AUTO_WALLPAPER_PERSIST_NOTIFICATION = "key_auto_wallpaper_persist_notification"
         private const val KEY_AUTO_WALLPAPER_PORTRAIT_MODE_ONLY = "key_auto_wallpaper_portrait_mode_only"
         private const val KEY_AUTO_WALLPAPER_SELECT_SCREEN = "key_auto_wallpaper_select_screen"
         private const val KEY_AUTO_WALLPAPER_ORIENTATION = "key_auto_wallpaper_orientation"
@@ -307,6 +313,7 @@ class AutoWallpaperWorker(
             KEY_AUTO_WALLPAPER_SEARCH_TERMS to sharedPreferencesRepository.autoWallpaperSearchTerms,
             KEY_AUTO_WALLPAPER_CROP to sharedPreferencesRepository.autoWallpaperCrop,
             KEY_AUTO_WALLPAPER_SHOW_NOTIFICATION to sharedPreferencesRepository.autoWallpaperShowNotification,
+            KEY_AUTO_WALLPAPER_PERSIST_NOTIFICATION to sharedPreferencesRepository.autoWallpaperPersistNotification,
             KEY_AUTO_WALLPAPER_PORTRAIT_MODE_ONLY to sharedPreferencesRepository.autoWallpaperPortraitModeOnly,
             KEY_AUTO_WALLPAPER_SELECT_SCREEN to sharedPreferencesRepository.autoWallpaperSelectScreen,
             KEY_AUTO_WALLPAPER_ORIENTATION to sharedPreferencesRepository.autoWallpaperOrientation,

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -279,4 +279,6 @@
     <string name="developer_title">الناشر</string>
     <string name="privacy_policy">سياسة الخصوية</string>
     <string name="terms_and_conditions">الأحكام والشروط</string>
+    <string name="auto_wallpaper_persist_notification_title">استمرار الإخطار</string>
+    <string name="auto_wallpaper_persist_notification_summary">اعرض دائمًا إشعار الخلفية الحالي</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -276,4 +276,6 @@
     <string name="developer_title">Vývojář</string>
     <string name="privacy_policy">Zásady ochrany osobních údajů</string>
     <string name="terms_and_conditions">Pravidla a podmínky</string>
+    <string name="auto_wallpaper_persist_notification_title">Trvalé oznámení</string>
+    <string name="auto_wallpaper_persist_notification_summary">Vždy zobrazit aktuální oznámení tapety</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -275,4 +275,6 @@
     <string name="developer_title">Entwickler</string>
     <string name="privacy_policy">Datenschutzerklärung</string>
     <string name="terms_and_conditions">Allgemeine Geschäftsbedingungen</string>
+    <string name="auto_wallpaper_persist_notification_title">Benachrichtigung beibehalten</string>
+    <string name="auto_wallpaper_persist_notification_summary">Zeigen Sie immer die aktuelle Hintergrundbenachrichtigung an</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -194,7 +194,7 @@
     <!-- User -->
     <string name="open_portfolio_link">Abrir enlace de portafolio</string>
     <string name="blank_username_error">Necesitamos saber como llamarte</string>
-    <string name="invalid_username_error">El nombre de usuario debe tener al menos un caracter y contener solo letras, dígitos o guiones bajos (sin espacios)</string>
+    <string name="invalid_username_error">El nombre de usuario debe tener al menos un carácter y contener solo letras, dígitos o guiones bajos (sin espacios)</string>
     <string name="username_taken_error">Nombre de usuario ya tomado</string>
     <string name="blank_first_name_error">El nombre no puede estar en blanco</string>
     <string name="blank_email_error">Email no puede estar en blanco</string>
@@ -275,4 +275,6 @@
     <string name="developer_title">Autor</string>
     <string name="privacy_policy">Política de privacidad</string>
     <string name="terms_and_conditions">Términos y condiciones</string>
+    <string name="auto_wallpaper_persist_notification_title">Notificación persistente</string>
+    <string name="auto_wallpaper_persist_notification_summary">Mostrar siempre la notificación de fondo de pantalla actual</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -276,4 +276,6 @@
     <string name="developer_title">Developer</string>
     <string name="privacy_policy">Politika privatnosti</string>
     <string name="terms_and_conditions">Uvjeti korištenja</string>
+    <string name="auto_wallpaper_persist_notification_title">Trajna obavijest</string>
+    <string name="auto_wallpaper_persist_notification_summary">Uvijek prikaži trenutnu obavijest o pozadini</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -275,4 +275,6 @@
     <string name="developer_title">Fejlesztő</string>
     <string name="privacy_policy">Privacy Policy</string>
     <string name="terms_and_conditions">Felhasználói &amp; Feltételek</string>
+    <string name="auto_wallpaper_persist_notification_title">Tartós értesítés</string>
+    <string name="auto_wallpaper_persist_notification_summary">Mindig jelenítse meg az aktuális háttérkép-értesítést</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -274,4 +274,6 @@
     <string name="developer_title">Pembuat</string>
     <string name="privacy_policy">Kebijakan Privasi</string>
     <string name="terms_and_conditions">Syarat dan ketentuan</string>
+    <string name="auto_wallpaper_persist_notification_title">Pemberitahuan Tetap</string>
+    <string name="auto_wallpaper_persist_notification_summary">Selalu tampilkan notifikasi wallpaper saat ini</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -275,4 +275,6 @@
     <string name="developer_title">Autore</string>
     <string name="privacy_policy">Privacy Policy</string>
     <string name="terms_and_conditions">Termini e Condizioni</string>
+    <string name="auto_wallpaper_persist_notification_title">Notifica persistente</string>
+    <string name="auto_wallpaper_persist_notification_summary">Mostra sempre la notifica dello sfondo corrente</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -274,4 +274,6 @@
     <string name="developer_title">開発者</string>
     <string name="privacy_policy">プライバシーポリシー</string>
     <string name="terms_and_conditions">利用規約</string>
+    <string name="auto_wallpaper_persist_notification_title">通知を永続化する</string>
+    <string name="auto_wallpaper_persist_notification_summary">常に現在の壁紙通知を表示する</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -275,4 +275,6 @@
     <string name="developer_title">Autor</string>
     <string name="privacy_policy">Política de Privacidade</string>
     <string name="terms_and_conditions">Termos e Condições</string>
+    <string name="auto_wallpaper_persist_notification_title">Persistir Notificação</string>
+    <string name="auto_wallpaper_persist_notification_summary">Sempre mostrar a notificação de papel de parede atual</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -277,4 +277,6 @@
     <string name="developer_title">Разработчик</string>
     <string name="privacy_policy">Политика конфиденциальности</string>
     <string name="terms_and_conditions">Условия и положения</string>
+    <string name="auto_wallpaper_persist_notification_title">Постоянное уведомление</string>
+    <string name="auto_wallpaper_persist_notification_summary">Всегда показывать текущее уведомление обоев</string>
 </resources>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -276,4 +276,6 @@
     <string name="developer_title">Аутор</string>
     <string name="privacy_policy">Правила о приватности</string>
     <string name="terms_and_conditions">Услови</string>
+    <string name="auto_wallpaper_persist_notification_title">Упорно обавештавање</string>
+    <string name="auto_wallpaper_persist_notification_summary">Увек прикажи тренутно обавештење о позадини</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -274,4 +274,6 @@
     <string name="developer_title">ผู้จัดทำ</string>
     <string name="privacy_policy">นโยบายความเป็นส่วนตัว</string>
     <string name="terms_and_conditions">ข้อกำหนดและเงื่อนไข</string>
+    <string name="auto_wallpaper_persist_notification_title">การแจ้งเตือนคงอยู่</string>
+    <string name="auto_wallpaper_persist_notification_summary">แสดงการแจ้งเตือนวอลเปเปอร์ปัจจุบันเสมอ</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -275,4 +275,6 @@
     <string name="developer_title">Yazar</string>
     <string name="privacy_policy">Gizlilik Politikası</string>
     <string name="terms_and_conditions">Şartlar ve koşullar</string>
+    <string name="auto_wallpaper_persist_notification_title">Kalıcı Bildirim</string>
+    <string name="auto_wallpaper_persist_notification_summary">Her zaman mevcut duvar kağıdı bildirimini göster</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -274,4 +274,6 @@
     <string name="developer_title">作者</string>
     <string name="privacy_policy">隐私权政策</string>
     <string name="terms_and_conditions">服务条款</string>
+    <string name="auto_wallpaper_persist_notification_title">持续通知</string>
+    <string name="auto_wallpaper_persist_notification_summary">始终显示当前墙纸通知</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,6 +159,8 @@
     <string name="auto_wallpaper_crop_center_crop">Center (Crop)</string>
     <string name="auto_wallpaper_notification_settings_title">Notification Settings</string>
     <string name="auto_wallpaper_show_notification_title">Show Notification</string>
+    <string name="auto_wallpaper_persist_notification_title">Persist Notification</string>
+    <string name="auto_wallpaper_persist_notification_summary">Always show the current wallpaper notification</string>
     <string name="auto_wallpaper_show_notification_summary">Get a notification with the current wallpaper info</string>
     <string name="auto_wallpaper_portrait_mode_only_title">Device Orientation Fix</string>
     <string name="auto_wallpaper_portrait_mode_only_summary">Some devices will crop the wallpaper incorrectly if it is set while the device is in landscape mode, checking this will reschedule the task until the device is in portrait mode</string>

--- a/app/src/main/res/xml/auto_wallpaper_preferences.xml
+++ b/app/src/main/res/xml/auto_wallpaper_preferences.xml
@@ -94,6 +94,12 @@
             app:summary="@string/auto_wallpaper_show_notification_summary"
             app:defaultValue="true" />
 
+        <CheckBoxPreference
+            app:key="auto_wallpaper_persist_notification"
+            app:title="@string/auto_wallpaper_persist_notification_title"
+            app:summary="@string/auto_wallpaper_persist_notification_summary"
+            app:defaultValue="false" />
+
         <ListPreference
             app:key="auto_wallpaper_crop"
             app:title="@string/auto_wallpaper_crop_title"


### PR DESCRIPTION
Added a setting to make the auto wallpaper notification persistent.

Minor UX improvement for a personal annoyance I had. If the notification gets cleared, it was annoying having to open the app, navigate to the auto wallpaper settings, and going into the wallpaper history just to open the current pic.

Not super well versed with Android native development atm so lmk if something's off.

Thanks!