### PR TITLE
Show navigation and status bar when clicking in PhotoZoomActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,7 +56,9 @@
         <activity
             android:name=".ui.collection.detail.CollectionDetailActivity"
             android:configChanges="orientation|screenSize" />
-        <activity android:name=".ui.photo.zoom.PhotoZoomActivity" />
+        <activity
+            android:name=".ui.photo.zoom.PhotoZoomActivity"
+            android:theme="@style/Resplash.Theme.DayNight.PhotoZoom" />
         <activity
             android:name=".ui.photo.detail.PhotoDetailActivity"
             android:theme="@style/Resplash.Theme.DayNight.PhotoDetail" />

--- a/app/src/main/java/com/b_lam/resplash/ui/photo/zoom/PhotoZoomActivity.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/photo/zoom/PhotoZoomActivity.kt
@@ -3,8 +3,9 @@ package com.b_lam.resplash.ui.photo.zoom
 import android.os.Build
 import android.os.Bundle
 import android.view.View
-import android.view.WindowInsets
-import android.view.WindowInsetsController
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.ViewModel
 import by.kirich1409.viewbindingdelegate.viewBinding
 import com.b_lam.resplash.R
@@ -19,31 +20,51 @@ class PhotoZoomActivity : BaseActivity(R.layout.activity_photo_zoom) {
 
     override val binding: ActivityPhotoZoomBinding by viewBinding()
 
+    private var isSystemUiVisible = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        toggleSystemUI(false)
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            window.setDecorFitsSystemWindows(false)
-            window.insetsController?.let {
-                it.hide(WindowInsets.Type.statusBars() or WindowInsets.Type.navigationBars())
-                it.systemBarsBehavior = WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            window.decorView.setOnApplyWindowInsetsListener { view, windowInsets ->
+                val suppliedInsets = view.onApplyWindowInsets(windowInsets)
+                isSystemUiVisible = suppliedInsets.isVisible(
+                    WindowInsetsCompat.Type.statusBars()
+                            or WindowInsetsCompat.Type.navigationBars()
+                )
+                suppliedInsets
             }
         } else {
-            window.decorView.systemUiVisibility = (View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                    or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                    or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                    or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                    or View.SYSTEM_UI_FLAG_FULLSCREEN
-                    or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
+            window.decorView.setOnSystemUiVisibilityChangeListener {
+                isSystemUiVisible = (it and View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0
+            }
+        }
+
+        binding.zoomImageView.setOnClickListener {
+            toggleSystemUI(!isSystemUiVisible)
         }
 
         val url = intent.getStringExtra(EXTRA_PHOTO_URL)
 
         url?.let {
             binding.zoomImageView.loadPhotoUrl(it)
-        }  ?: run {
+        } ?: run {
             toast(R.string.oops)
             finish()
+        }
+    }
+
+    private fun toggleSystemUI(showSystemUI: Boolean) {
+        WindowInsetsControllerCompat(window, binding.root).let {
+            it.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            if (showSystemUI) {
+                it.show(WindowInsetsCompat.Type.statusBars() or WindowInsetsCompat.Type.navigationBars())
+            } else {
+                it.hide(WindowInsetsCompat.Type.statusBars() or WindowInsetsCompat.Type.navigationBars())
+            }
         }
     }
 

--- a/app/src/main/java/com/b_lam/resplash/ui/photo/zoom/PhotoZoomActivity.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/photo/zoom/PhotoZoomActivity.kt
@@ -26,7 +26,7 @@ class PhotoZoomActivity : BaseActivity(R.layout.activity_photo_zoom) {
         super.onCreate(savedInstanceState)
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
-        toggleSystemUI(false)
+        toggleSystemUi(false)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             window.decorView.setOnApplyWindowInsetsListener { view, windowInsets ->
@@ -44,7 +44,7 @@ class PhotoZoomActivity : BaseActivity(R.layout.activity_photo_zoom) {
         }
 
         binding.zoomImageView.setOnClickListener {
-            toggleSystemUI(!isSystemUiVisible)
+            toggleSystemUi(!isSystemUiVisible)
         }
 
         val url = intent.getStringExtra(EXTRA_PHOTO_URL)
@@ -57,10 +57,10 @@ class PhotoZoomActivity : BaseActivity(R.layout.activity_photo_zoom) {
         }
     }
 
-    private fun toggleSystemUI(showSystemUI: Boolean) {
+    private fun toggleSystemUi(showSystemUi: Boolean) {
         WindowInsetsControllerCompat(window, binding.root).let {
             it.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-            if (showSystemUI) {
+            if (showSystemUi) {
                 it.show(WindowInsetsCompat.Type.statusBars() or WindowInsetsCompat.Type.navigationBars())
             } else {
                 it.hide(WindowInsetsCompat.Type.statusBars() or WindowInsetsCompat.Type.navigationBars())

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -18,6 +18,12 @@
         <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
     </style>
 
+    <style name="Resplash.Theme.DayNight.PhotoZoom">
+        <item name="android:statusBarColor">@color/immersive_sys_ui</item>
+        <item name="android:navigationBarColor">@color/immersive_sys_ui</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
+    </style>
+
     <!-- Base custom theme which will be shared between both light and dark theme variants -->
     <style name="Base.Theme" parent="Base.MaterialThemeBuilder">
         <!-- Material color attributes -->


### PR DESCRIPTION
I have added the feature as described in issue #140.
The user can click anywhere in the photo preview to show or hide the system UI. The navigation and status bar is displayed translucent above the current picture.

![wQjB8NLiEc](https://user-images.githubusercontent.com/29163322/132098760-4cbb7373-a593-4f23-ac7c-1183c06def3c.gif)
