### PR TITLE
Minor System UI improvements for PhotoZoomActivity

### DIFF
--- a/app/src/main/java/com/b_lam/resplash/ui/photo/zoom/PhotoZoomActivity.kt
+++ b/app/src/main/java/com/b_lam/resplash/ui/photo/zoom/PhotoZoomActivity.kt
@@ -26,7 +26,9 @@ class PhotoZoomActivity : BaseActivity(R.layout.activity_photo_zoom) {
         super.onCreate(savedInstanceState)
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
-        toggleSystemUi(false)
+        window.decorView.post {
+            toggleSystemUi(false)
+        }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             window.decorView.setOnApplyWindowInsetsListener { view, windowInsets ->

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -22,6 +22,8 @@
         <item name="android:statusBarColor">@color/immersive_sys_ui</item>
         <item name="android:navigationBarColor">@color/immersive_sys_ui</item>
         <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
+        <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">false</item>
+        <item name="android:windowLayoutInDisplayCutoutMode" tools:targetApi="o_mr1">shortEdges</item>
     </style>
 
     <!-- Base custom theme which will be shared between both light and dark theme variants -->


### PR DESCRIPTION
Fixed system UI backgrounds were transparent on first click (only appeared on devices running < Android 11).
- fixed by hiding system UI once the decor view is ready (`window.decorView.post`)

Fixed navigation bar controls were not displayed light.

Fixed content resizing on devices with display cutouts when system UI reappeared.
- use `shortEdges` cutout mode as described in the [official documentation](https://developer.android.com/guide/topics/display-cutout#render_content_in_short_edge_cutout_areas)