### PR TITLE
Fixed issue with persistant notifications getting cleared on tap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ lint/generated/
 lint/outputs/
 lint/tmp/
 lint/reports/
+
+# misc
+.DS_Store

--- a/app/src/main/java/com/b_lam/resplash/util/NotificationManager.kt
+++ b/app/src/main/java/com/b_lam/resplash/util/NotificationManager.kt
@@ -118,7 +118,7 @@ class NotificationManager(private val context: Context) {
             priority = NotificationCompat.PRIORITY_MIN
             setSmallIcon(R.drawable.ic_resplash_24dp)
             setContentIntent(getCurrentWallpaperPendingIntent(id))
-            setAutoCancel(persist)
+            setAutoCancel(!persist)
             title?.let { setContentTitle(it) }
             subtitle?.let { setContentText(it) }
             previewUrl?.let {


### PR DESCRIPTION
Inverting `persist` since setAutoCancel needs to be false for persistence.
Also ignoring .DS_Store files.

I know this is like so long after I first implemented persistent notifications. Had these changes from a while back and just forgot about them.