### PR TITLE
Updated icons to match Material You theming

### DIFF
--- a/app/src/debug/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/debug/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground" />
 </adaptive-icon>

--- a/app/src/debug/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/debug/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
In Android 13 Google introduced themed monochrome icons: [https://developer.android.com/develop/ui/views/launch/icon_design_adaptive](https://developer.android.com/develop/ui/views/launch/icon_design_adaptive), and this pull request updates adaptive icon parameters to allow themed icons to be displayed at user request. Since the icons are monochrome, no changes to the icons were applied.


Standard icon (left) compared to material you icon (right):

![](https://user-images.githubusercontent.com/40764618/205524090-29a5b745-5109-4f60-8a5f-172cd697a734.png)

Material You Themed Icons with light theme:

![](https://user-images.githubusercontent.com/40764618/205524069-02a90f71-f21c-436c-a412-aa97074c2672.png)

Material You Themed Icons disabled:

![](https://user-images.githubusercontent.com/40764618/205524035-9bf4e79b-14bc-4ffb-8c00-1b7f3d8a2f01.png)




